### PR TITLE
Feature/forget password

### DIFF
--- a/Backend/settings/base.py
+++ b/Backend/settings/base.py
@@ -88,6 +88,7 @@ REST_AUTH_REGISTER_SERIALIZERS = {
 
 REST_AUTH_SERIALIZERS = {
     'LOGIN_SERIALIZER': 'membership.serializers.LoginSerializer',
+    'PASSWORD_RESET_SERIALIZER': 'membership.serializers.PasswordResetSerializer',
 }
 
 REST_FRAMEWORK = {

--- a/membership/forms.py
+++ b/membership/forms.py
@@ -1,0 +1,82 @@
+from django import forms
+
+from django.core.mail import EmailMultiAlternatives
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.contrib.auth.forms import PasswordResetForm as DefaultPasswordResetForm
+from django.contrib.sites.shortcuts import get_current_site
+
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from django.utils.translation import ugettext_lazy as _
+
+from django.template import loader
+
+class PasswordResetForm(DefaultPasswordResetForm):
+
+    def send_mail(self, subject_template_name, email_template_name,
+                context, from_email, to_email, html_email_template_name=None):
+        subject = loader.render_to_string(subject_template_name, context)
+        # Email subject *must not* contain newlines
+        subject = ''.join(subject.splitlines())
+        body = loader.render_to_string(email_template_name, context)
+
+        email_message = EmailMultiAlternatives(subject, body, from_email, [to_email])
+        if html_email_template_name is not None:
+            html_email = loader.render_to_string(html_email_template_name, context)
+            email_message.attach_alternative(html_email, 'text/html')
+
+        email_message.send()
+
+    def get_users(self, email):
+        """Given an email, return matching user(s) who should receive a reset.
+        This allows subclasses to more easily customize the default policies
+        that prevent inactive users and users with unusable passwords from
+        resetting their password.
+        """
+        from allauth.account.models import EmailAddress
+
+        return EmailAddress.objects.get(email=email, primary=True).user
+
+    def save(self, domain_override=None,
+             subject_template_name='registration/password_reset_subject.txt',
+             email_template_name='registration/password_reset_email.html',
+             use_https=False, token_generator=default_token_generator,
+             from_email=None, request=None, html_email_template_name=None,
+             extra_email_context=None):
+        """
+        Generate a one-use only link for resetting password and send it to the
+        user.
+        """
+        email = self.cleaned_data["email"]
+        try: 
+            user = self.get_users(email)
+            if not domain_override:
+                current_site = get_current_site(request)
+                site_name = current_site.name
+                domain = current_site.domain
+            else:
+                site_name = domain = domain_override
+            context = {
+                'email': email,
+                'domain': domain,
+                'site_name': site_name,
+                'uid': urlsafe_base64_encode(force_bytes(user.pk)).decode(),
+                'user': user,
+                'token': token_generator.make_token(user),
+                'protocol': 'https' if use_https else 'http',
+            }
+            # print(context)
+            if extra_email_context is not None:
+                context.update(extra_email_context)
+            self.send_mail(
+                subject_template_name, email_template_name, context, from_email,
+                email, html_email_template_name=html_email_template_name,
+            )
+        except: 
+            raise forms.ValidationError(
+                _('this email (%(value)s) doesn\'t matches with our customer'),
+                code='password_mismatch',
+                params={'value': email}
+            )

--- a/membership/serializers.py
+++ b/membership/serializers.py
@@ -6,15 +6,25 @@ from payment.serializers import CreditCardSerializer, FullCreditCardSerializer
 from allauth.account.models import EmailAddress
 
 from payment.serializers import CreditCardSerializer, FullCreditCardSerializer
-from rest_auth.serializers import LoginSerializer as DefaultLoginSerializer
+
+from membership.forms import PasswordResetForm
+
+from rest_auth.serializers import (
+    LoginSerializer as DefaultLoginSerializer,
+    PasswordResetSerializer as DefaultPasswordResetSerializer
+)
 
 from rest_framework import serializers, exceptions
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import ( 
+    APIException, 
+    NotAcceptable
+)
 
+from django.core.exceptions import ValidationError
 from django.contrib.auth import get_user_model, authenticate
 from django.contrib.auth.hashers import make_password
 from django.conf import settings
-from django.core.exceptions import ValidationError, NON_FIELD_ERRORS
+
 from django.utils.translation import ugettext_lazy as _
 from django.db.utils import IntegrityError
 
@@ -196,3 +206,13 @@ class LoginSerializer(DefaultLoginSerializer):
 
         attrs['user'] = user
         return attrs
+
+
+class PasswordResetSerializer(DefaultPasswordResetSerializer):
+    password_reset_form_class = PasswordResetForm
+
+    def save(self):
+        try:
+            super(PasswordResetSerializer, self).save()
+        except ValidationError as e:
+            raise NotAcceptable(e.messages[0])

--- a/membership/templates/registration/password_reset_email.html
+++ b/membership/templates/registration/password_reset_email.html
@@ -1,0 +1,14 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+
+{% trans "Please go to the following page and choose a new password:" %}
+{% block reset_link %}
+http://localhost:3000/password/reset/{{ uid }}/{{ token }}
+{% endblock %}
+{% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
+
+{% trans "Thanks for using our site!" %}
+
+{% blocktrans %}The {{ site_name }} team{% endblocktrans %}
+
+{% endautoescape %}

--- a/membership/urls.py
+++ b/membership/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url, include
-from membership.views import CustomerDetail, UserDetail, ClassDetail, ConfirmEmailView, completed_register  # , CustomerList
+from membership.views import CustomerDetail, UserDetail, ClassDetail, ConfirmEmailView, completed_register
 
 urlpatterns = [
     # url(r'^django-auth', include('django.contrib.auth.urls')),

--- a/membership/views.py
+++ b/membership/views.py
@@ -11,6 +11,11 @@ from utilities.classes.database import ImpDetailByTokenView
 from utilities.classes.database import ImpUpdateByTokenView
 
 
+
+from django.utils.translation import ugettext_lazy as _
+from rest_auth.views import PasswordResetView
+
+
 class CustomerDetail(ImpDetailByTokenView):
     queryset = Customer.objects.all()
     serializer_class = FullCustomerSerializer


### PR DESCRIPTION
## What kind of change does this PR introduce?
fix forget password flow.

## Description
Workflow
1. call `reset_password`
     - program will send email to your input email
     - link: <domain>/membership/password/reset/
2. click on link on that email
     - link might have to change, when frontend implemented
     - link will end with <FRONTEND_URL>/<uid>/<token>
3. input new `password1` and `password2`
4. frontend will call `reset_password_confirm` to confirm new password
     - link: <domain>/membership/password/reset/
     - required: uid, token, password1, password2

## The PR fulfills these requirements:
- [X] merge with latest version in `dev` branch
- [X] run pass all testcase, if it have

<!-- delete this line if you need comment or more detail  
## Other information:
...
delete this line if you need comment or more detail -->
